### PR TITLE
Add cross-platform threading support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,27 @@ This library enables easy integration of VectorNAV sensors with PlatformIO and A
 ## About
 This library is based on the official VectorNAV SDK and has been adapted to work seamlessly with PlatformIO and Arduino-compatible platforms. It provides a C++ interface for communicating with VectorNAV sensors while maintaining compatibility with the original SDK's functionality.
 
+## Supported Platforms
+
+This library is designed to work with multiple microcontroller platforms:
+
+- **Teensy** - Full threading support using TeensyThreads
+- **ESP32** - Native threading support using FreeRTOS
+- **STM32** - Threading support when CMSIS-RTOS is enabled
+- **Other Arduino-compatible platforms** - Fallback implementation without threading
+
+The library automatically detects the platform and uses the appropriate implementation.
+
+### Disabling Threading
+
+If you want to disable threading on any platform, you can add the following flag to your `platformio.ini` file:
+
+```ini
+build_flags = -DTHREADING_ENABLE=false
+```
+
+This will force the library to use the non-threaded implementation regardless of platform.
+
 ## Installation
 
 Add this library to your PlatformIO project's dependencies in your `platformio.ini` file:

--- a/include/HAL/Thread.hpp
+++ b/include/HAL/Thread.hpp
@@ -24,6 +24,22 @@
 #ifndef HAL_THREAD_HPP
 #define HAL_THREAD_HPP
 
-#include "HAL/Thread_Mbed.hpp"
+// プラットフォーム検出と適切なスレッド実装の選択
+#if defined(TEENSYDUINO)
+    // Teensy用の実装
+    #include "HAL/Thread_Mbed.hpp"
+#elif defined(ESP32)
+    // ESP32用の実装
+    #include "HAL/Thread_ESP32.hpp"
+#elif defined(ARDUINO_ARCH_STM32) && defined(ARDUINO_CMSIS_RTOS_ENABLED)
+    // STM32 + CMSIS-RTOS用の実装
+    #include "HAL/Thread_STM32.hpp"
+#elif defined(THREADING_ENABLE) && (THREADING_ENABLE == false)
+    // スレッドを明示的に無効化
+    #include "HAL/Thread_Disabled.hpp"
+#else
+    // その他のプラットフォーム用のフォールバック実装
+    #include "HAL/Thread_Disabled.hpp"
+#endif
 
 #endif  // HAL_THREAD_HPP

--- a/include/HAL/Thread_Disabled.hpp
+++ b/include/HAL/Thread_Disabled.hpp
@@ -1,0 +1,137 @@
+// The MIT License (MIT)
+//
+// Copyright (c) Hidaka SATO
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef HAL_THREAD_DISABLED_HPP
+#define HAL_THREAD_DISABLED_HPP
+
+#include <Arduino.h>
+#include <functional>
+#include <utility>
+#include "HAL/Thread_Base.hpp"
+
+namespace VN
+{
+
+/**
+ * @brief スレッドなし実装（フォールバック）
+ *
+ * スレッドをサポートしないプラットフォーム用のフォールバック実装です。
+ * この実装では、スレッド作成時に関数が即時実行され、非同期処理は行われません。
+ */
+class Thread : public Thread_Base
+{
+public:
+    // スレッドのコピーは禁止
+    Thread(const Thread&) = delete;
+    Thread& operator=(const Thread&) = delete;
+
+    /**
+     * @brief デフォルトコンストラクタ
+     */
+    Thread() = default;
+
+    /**
+     * @brief コンストラクタ：関数オブジェクト + 引数を受け取り、即時実行
+     *
+     * この実装では、スレッドは作成されず、関数が即時実行されます。
+     */
+    template <typename Callable, typename... Args>
+    explicit Thread(Callable&& f, Args&&... args)
+    {
+        // 呼び出す関数をバインドして保存
+        _func = std::bind(std::forward<Callable>(f), std::forward<Args>(args)...);
+        
+        // 即時実行
+        if (_func) {
+            _func();
+            _executed = true;
+        }
+    }
+
+    /**
+     * @brief デストラクタ
+     */
+    ~Thread() override = default;
+
+    /**
+     * @brief スレッド終了を待機（この実装では何もしない）
+     */
+    void join() override final
+    {
+        // 即時実行されるため、何もする必要がない
+    }
+
+    /**
+     * @brief スレッドのデタッチ（この実装では何もしない）
+     */
+    void detach() override final
+    {
+        // 即時実行されるため、何もする必要がない
+    }
+
+    /**
+     * @brief スレッドがまだ実行中かどうか
+     * 
+     * この実装では常にfalseを返します（即時実行されるため）
+     */
+    bool joinable() const override final
+    {
+        return false;
+    }
+
+private:
+    // ユーザが指定した関数を保持する
+    std::function<void()> _func;
+    
+    // 実行済みフラグ
+    bool _executed = false;
+};
+
+/**
+ * @brief 現在実行中のスレッドを操作するための名前空間
+ */
+namespace thisThread
+{
+    /**
+     * @brief 指定したマイクロ秒だけスリープ (ブロック)
+     */
+    inline void sleepFor(const Microseconds sleepDuration) noexcept
+    {
+        // マイクロ秒値をミリ秒 + 残りマイクロ秒に分割
+        const uint64_t totalUs = static_cast<uint64_t>(sleepDuration.count());
+        const uint32_t ms = static_cast<uint32_t>(totalUs / 1000ULL);
+        const uint32_t us = static_cast<uint32_t>(totalUs % 1000ULL);
+
+        if (ms > 0)
+        {
+            delay(ms);
+        }
+        if (us > 0)
+        {
+            delayMicroseconds(us);
+        }
+    }
+}  // namespace thisThread
+
+}  // namespace VN
+
+#endif  // HAL_THREAD_DISABLED_HPP

--- a/include/HAL/Thread_ESP32.hpp
+++ b/include/HAL/Thread_ESP32.hpp
@@ -1,0 +1,239 @@
+// The MIT License (MIT)
+//
+// Copyright (c) Hidaka SATO
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef HAL_THREAD_ESP32_HPP
+#define HAL_THREAD_ESP32_HPP
+
+#include <Arduino.h>
+#include <functional>
+#include <utility>
+#include "HAL/Thread_Base.hpp"
+
+#ifdef ESP32
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <freertos/semphr.h>
+#endif
+
+namespace VN
+{
+
+/**
+ * @brief ESP32 + FreeRTOS を使ったスレッドクラス
+ *
+ * PC版の std::thread ライクなインターフェースを模倣しています。
+ * - `join()` : スレッド終了まで待機
+ * - `detach()` : デタッチ
+ * - `joinable()` : スレッドが現在アクティブかどうか
+ */
+class Thread : public Thread_Base
+{
+public:
+    // スレッドのコピーは禁止
+    Thread(const Thread&) = delete;
+    Thread& operator=(const Thread&) = delete;
+
+    /**
+     * @brief デフォルトコンストラクタ (スレッドをまだ作成しない)
+     */
+    Thread() = default;
+
+    /**
+     * @brief コンストラクタ：関数オブジェクト + 引数を受け取り、スレッドを起動
+     *
+     * std::thread と同様の書き方でスレッドを生成できます。
+     * 例: `Thread t([]{ ... });`
+     */
+    template <typename Callable, typename... Args>
+    explicit Thread(Callable&& f, Args&&... args)
+    {
+        // 呼び出す関数をバインドして保存
+        _func = std::bind(std::forward<Callable>(f), std::forward<Args>(args)...);
+
+#ifdef ESP32
+        // 完了通知用のセマフォを作成
+        _completionSemaphore = xSemaphoreCreateBinary();
+        
+        // FreeRTOSタスクを作成
+        BaseType_t result = xTaskCreate(
+            Thread::_runTrampoline,  // タスク関数
+            "VN_Thread",             // タスク名
+            4096,                    // スタックサイズ
+            this,                    // パラメータ
+            1,                       // 優先度
+            &_taskHandle             // タスクハンドル
+        );
+        
+        if (result != pdPASS) {
+            // タスク作成失敗
+            _taskHandle = nullptr;
+            if (_completionSemaphore) {
+                vSemaphoreDelete(_completionSemaphore);
+                _completionSemaphore = nullptr;
+            }
+        }
+#else
+        // ESP32以外の場合は即時実行
+        if (_func) {
+            _func();
+        }
+#endif
+    }
+
+    /**
+     * @brief デストラクタ
+     *
+     * PC 版の実装では joinable() なら join() しますが、
+     * こちらも同じ挙動をとっています。
+     * スレッドがまだ生きていれば終了を待機するため、注意してください。
+     */
+    ~Thread() override
+    {
+        if (joinable())
+        {
+            join();
+        }
+        
+#ifdef ESP32
+        // セマフォの削除
+        if (_completionSemaphore) {
+            vSemaphoreDelete(_completionSemaphore);
+            _completionSemaphore = nullptr;
+        }
+#endif
+    }
+
+    /**
+     * @brief スレッド終了を待機
+     */
+    void join() override final
+    {
+#ifdef ESP32
+        if (joinable() && _completionSemaphore)
+        {
+            // セマフォが解放されるまで待機
+            xSemaphoreTake(_completionSemaphore, portMAX_DELAY);
+            xSemaphoreGive(_completionSemaphore);  // 再度解放して他のwaitが動作するようにする
+            
+            _taskHandle = nullptr;
+        }
+#endif
+    }
+
+    /**
+     * @brief スレッドのデタッチ
+     */
+    void detach() override final
+    {
+#ifdef ESP32
+        if (joinable())
+        {
+            _taskHandle = nullptr;  // ハンドルを解放するだけ
+        }
+#endif
+    }
+
+    /**
+     * @brief スレッドがまだ実行中かどうか
+     */
+    bool joinable() const override final
+    {
+#ifdef ESP32
+        return _taskHandle != nullptr;
+#else
+        return false;
+#endif
+    }
+
+private:
+#ifdef ESP32
+    // スレッド実行時に呼び出される静的関数
+    static void _runTrampoline(void* arg)
+    {
+        auto self = static_cast<Thread*>(arg);
+        if (self && self->_func)
+        {
+            self->_func();
+            
+            // 完了を通知
+            if (self->_completionSemaphore) {
+                xSemaphoreGive(self->_completionSemaphore);
+            }
+        }
+        
+        // タスク終了
+        vTaskDelete(NULL);
+    }
+
+    // FreeRTOSタスクハンドル
+    TaskHandle_t _taskHandle = nullptr;
+    
+    // 完了通知用セマフォ
+    SemaphoreHandle_t _completionSemaphore = nullptr;
+#endif
+
+    // ユーザが指定した関数を保持する
+    std::function<void()> _func;
+};
+
+/**
+ * @brief 現在実行中のスレッドを操作するための名前空間
+ */
+namespace thisThread
+{
+    /**
+     * @brief 指定したマイクロ秒だけスリープ (ブロック)
+     */
+    inline void sleepFor(const Microseconds sleepDuration) noexcept
+    {
+#ifdef ESP32
+        // FreeRTOSのディレイ関数を使用
+        const uint64_t totalUs = static_cast<uint64_t>(sleepDuration.count());
+        const uint32_t ms = static_cast<uint32_t>(totalUs / 1000ULL);
+        
+        if (ms > 0) {
+            vTaskDelay(pdMS_TO_TICKS(ms));
+        } else {
+            // 1ms未満の場合はArduinoの関数を使用
+            delayMicroseconds(static_cast<uint32_t>(totalUs));
+        }
+#else
+        // ESP32以外の場合はArduinoの関数を使用
+        const uint64_t totalUs = static_cast<uint64_t>(sleepDuration.count());
+        const uint32_t ms = static_cast<uint32_t>(totalUs / 1000ULL);
+        const uint32_t us = static_cast<uint32_t>(totalUs % 1000ULL);
+
+        if (ms > 0)
+        {
+            delay(ms);
+        }
+        if (us > 0)
+        {
+            delayMicroseconds(us);
+        }
+#endif
+    }
+}  // namespace thisThread
+
+}  // namespace VN
+
+#endif  // HAL_THREAD_ESP32_HPP

--- a/include/HAL/Thread_STM32.hpp
+++ b/include/HAL/Thread_STM32.hpp
@@ -1,0 +1,228 @@
+// The MIT License (MIT)
+//
+// Copyright (c) Hidaka SATO
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef HAL_THREAD_STM32_HPP
+#define HAL_THREAD_STM32_HPP
+
+#include <Arduino.h>
+#include <functional>
+#include <utility>
+#include "HAL/Thread_Base.hpp"
+
+// STM32 + CMSIS-RTOS/FreeRTOS
+#if defined(ARDUINO_ARCH_STM32) && defined(ARDUINO_CMSIS_RTOS_ENABLED)
+#include <STM32FreeRTOS.h>
+#include <cmsis_os.h>
+#endif
+
+namespace VN
+{
+
+/**
+ * @brief STM32 + CMSIS-RTOS/FreeRTOS を使ったスレッドクラス
+ *
+ * PC版の std::thread ライクなインターフェースを模倣しています。
+ * - `join()` : スレッド終了まで待機
+ * - `detach()` : デタッチ
+ * - `joinable()` : スレッドが現在アクティブかどうか
+ */
+class Thread : public Thread_Base
+{
+public:
+    // スレッドのコピーは禁止
+    Thread(const Thread&) = delete;
+    Thread& operator=(const Thread&) = delete;
+
+    /**
+     * @brief デフォルトコンストラクタ (スレッドをまだ作成しない)
+     */
+    Thread() = default;
+
+    /**
+     * @brief コンストラクタ：関数オブジェクト + 引数を受け取り、スレッドを起動
+     *
+     * std::thread と同様の書き方でスレッドを生成できます。
+     * 例: `Thread t([]{ ... });`
+     */
+    template <typename Callable, typename... Args>
+    explicit Thread(Callable&& f, Args&&... args)
+    {
+        // 呼び出す関数をバインドして保存
+        _func = std::bind(std::forward<Callable>(f), std::forward<Args>(args)...);
+
+#if defined(ARDUINO_ARCH_STM32) && defined(ARDUINO_CMSIS_RTOS_ENABLED)
+        // スレッド属性の設定
+        osThreadAttr_t threadAttr = {
+            .name = "VN_Thread",
+            .stack_size = 4096,
+            .priority = osPriorityNormal,
+        };
+        
+        // CMSIS-RTOSスレッドを作成
+        _threadId = osThreadNew(Thread::_runTrampoline, this, &threadAttr);
+        
+        if (_threadId == nullptr) {
+            // スレッド作成失敗
+            _active = false;
+        } else {
+            _active = true;
+        }
+#else
+        // STM32 CMSIS-RTOS以外の場合は即時実行
+        if (_func) {
+            _func();
+        }
+#endif
+    }
+
+    /**
+     * @brief デストラクタ
+     *
+     * PC 版の実装では joinable() なら join() しますが、
+     * こちらも同じ挙動をとっています。
+     * スレッドがまだ生きていれば終了を待機するため、注意してください。
+     */
+    ~Thread() override
+    {
+        if (joinable())
+        {
+            join();
+        }
+    }
+
+    /**
+     * @brief スレッド終了を待機
+     */
+    void join() override final
+    {
+#if defined(ARDUINO_ARCH_STM32) && defined(ARDUINO_CMSIS_RTOS_ENABLED)
+        if (joinable() && _threadId != nullptr)
+        {
+            // スレッド終了を待機
+            osThreadJoin(_threadId);
+            _threadId = nullptr;
+            _active = false;
+        }
+#endif
+    }
+
+    /**
+     * @brief スレッドのデタッチ
+     */
+    void detach() override final
+    {
+#if defined(ARDUINO_ARCH_STM32) && defined(ARDUINO_CMSIS_RTOS_ENABLED)
+        if (joinable())
+        {
+            // STM32 CMSIS-RTOSではデタッチの概念がないため、
+            // ハンドルを解放するだけ
+            _threadId = nullptr;
+            _active = false;
+        }
+#endif
+    }
+
+    /**
+     * @brief スレッドがまだ実行中かどうか
+     */
+    bool joinable() const override final
+    {
+#if defined(ARDUINO_ARCH_STM32) && defined(ARDUINO_CMSIS_RTOS_ENABLED)
+        return _active && _threadId != nullptr;
+#else
+        return false;
+#endif
+    }
+
+private:
+#if defined(ARDUINO_ARCH_STM32) && defined(ARDUINO_CMSIS_RTOS_ENABLED)
+    // スレッド実行時に呼び出される静的関数
+    static void _runTrampoline(void* arg)
+    {
+        auto self = static_cast<Thread*>(arg);
+        if (self && self->_func)
+        {
+            self->_func();
+        }
+        
+        // スレッド終了時に自動的に状態を更新
+        if (self) {
+            self->_active = false;
+        }
+        
+        // スレッド終了
+        osThreadExit();
+    }
+
+    // CMSIS-RTOSスレッドID
+    osThreadId_t _threadId = nullptr;
+    
+    // スレッドがアクティブかどうか
+    bool _active = false;
+#endif
+
+    // ユーザが指定した関数を保持する
+    std::function<void()> _func;
+};
+
+/**
+ * @brief 現在実行中のスレッドを操作するための名前空間
+ */
+namespace thisThread
+{
+    /**
+     * @brief 指定したマイクロ秒だけスリープ (ブロック)
+     */
+    inline void sleepFor(const Microseconds sleepDuration) noexcept
+    {
+#if defined(ARDUINO_ARCH_STM32) && defined(ARDUINO_CMSIS_RTOS_ENABLED)
+        // CMSIS-RTOSのディレイ関数を使用
+        const uint64_t totalUs = static_cast<uint64_t>(sleepDuration.count());
+        const uint32_t ms = static_cast<uint32_t>(totalUs / 1000ULL);
+        
+        if (ms > 0) {
+            osDelay(ms);
+        } else {
+            // 1ms未満の場合はArduinoの関数を使用
+            delayMicroseconds(static_cast<uint32_t>(totalUs));
+        }
+#else
+        // STM32 CMSIS-RTOS以外の場合はArduinoの関数を使用
+        const uint64_t totalUs = static_cast<uint64_t>(sleepDuration.count());
+        const uint32_t ms = static_cast<uint32_t>(totalUs / 1000ULL);
+        const uint32_t us = static_cast<uint32_t>(totalUs % 1000ULL);
+
+        if (ms > 0)
+        {
+            delay(ms);
+        }
+        if (us > 0)
+        {
+            delayMicroseconds(us);
+        }
+#endif
+    }
+}  // namespace thisThread
+
+}  // namespace VN
+
+#endif  // HAL_THREAD_STM32_HPP

--- a/library.json
+++ b/library.json
@@ -26,7 +26,11 @@
         "-std=gnu++17"
       ]
     },
-    "dependencies": {
-      "TeensyThreads": "https://github.com/ftrias/TeensyThreads.git"
-    }
+    "dependencies": [
+      {
+        "name": "TeensyThreads",
+        "version": "https://github.com/ftrias/TeensyThreads.git",
+        "platforms": "teensy"
+      }
+    ]
   }


### PR DESCRIPTION
## 概要

このプルリクエストは、Issue #1 で提起された問題を解決するものです。VectorNav-PIOライブラリがTeensyThreadsに依存していることで、他のマイコンプラットフォームとの互換性が制限されていました。

## 変更内容

1. **プラットフォーム検出メカニズムの実装**
   - `Thread.hpp`を更新し、コンパイル時にプラットフォームを検出して適切なスレッド実装を選択するようにしました

2. **複数のプラットフォーム向けスレッド実装の追加**
   - `Thread_ESP32.hpp` - ESP32向けのFreeRTOSベースの実装
   - `Thread_STM32.hpp` - STM32 + CMSIS-RTOS向けの実装
   - `Thread_Disabled.hpp` - スレッドをサポートしないプラットフォーム向けのフォールバック実装

3. **TeensyThreadsを条件付き依存関係に変更**
   - `library.json`を更新し、TeensyThreadsをTeensyプラットフォームのみの依存関係に変更

4. **ドキュメントの更新**
   - READMEに対応プラットフォームの情報を追加
   - スレッドを無効化する方法の説明を追加

## テスト

この変更により、以下のプラットフォームでライブラリが動作するようになります：

- Teensy (既存の実装を維持)
- ESP32 (FreeRTOSベースの新しい実装)
- STM32 (CMSIS-RTOSが有効な場合)
- その他のArduino互換プラットフォーム (スレッドなしのフォールバック実装)

また、`-DTHREADING_ENABLE=false`フラグを使用することで、どのプラットフォームでもスレッドを無効化できるようになりました。

このプルリクエストはIssue #1 を解決します。